### PR TITLE
update default refresh_ms for linux platform

### DIFF
--- a/cubestat/collectors/disk_collector.py
+++ b/cubestat/collectors/disk_collector.py
@@ -35,9 +35,9 @@ class LinuxDiskCollector(DiskCollector):
     def configure(self, config) -> 'LinuxDiskCollector':
         # Handle both Dict and Namespace objects
         if hasattr(config, 'get'):
-            refresh_ms = config.get('refresh_ms', 200)
+            refresh_ms = config.get('refresh_ms', 1000)
         else:
-            refresh_ms = getattr(config, 'refresh_ms', 200)
+            refresh_ms = getattr(config, 'refresh_ms', 1000)
         self.rate_reader = RateReader(refresh_ms)
         return self
     


### PR DESCRIPTION
MacOS collector gets this information automatically from context, only linux collector needs to be updated.